### PR TITLE
Remove NUR and update Nix development environment.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,6 @@
+{ pkgs ? import <nixpkgs> {}}:
+
+pkgs.buildEnv {
+    name="lz4-frame-conduit-development";
+    paths=[pkgs.stack];
+}

--- a/nix/haskell-dependencies.nix
+++ b/nix/haskell-dependencies.nix
@@ -1,0 +1,15 @@
+haskellPackages:
+  with haskellPackages; [
+    conduit
+    conduit-extra
+    inline-c
+    optparse-applicative
+    raw-strings-qq
+    resourcet
+    unliftio
+    unliftio-core
+
+    # Tests
+    QuickCheck
+    hspec
+  ]

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -1,11 +1,13 @@
+{}:
 with (import <nixpkgs> {});
+
 let
-  # Needs NUR from https://github.com/nix-community/NUR
-  ghc = nur.repos.mpickering.ghc.ghc865; # Keep in sync with the GHC version defined by stack.yaml!
+  mkDependencies = import ./nix/haskell-dependencies.nix;
 in
   haskell.lib.buildStackProject {
-    inherit ghc;
-    name = "myEnv";
+    name = "lz4-frame-conduit-stack";
+
+    ghc = haskellPackages.ghcWithHoogle mkDependencies;
 
     # System dependencies used at build-time go in here.
     nativeBuildInputs = [

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,8 @@
-resolver: lts-13.26
-extra-deps:
-# TODO: Remove all of the below when we are on a resolver that has hspec >= 2.7.2
-#       which fixes slow failure diffs, see https://github.com/hspec/hspec/issues/415.
-- hspec-2.7.4
-- hspec-core-2.7.4
-- hspec-discover-2.7.4
-- QuickCheck-2.14.1
-- random-1.2.0
-- splitmix-0.1.0.1
+resolver: ghc-9.0.2
+
+allow-newer: true
+rebuild-ghc-options: true
+
+nix:
+  enable: true
+  shell-file: stack-shell.nix


### PR DESCRIPTION
To ease development on this package this PR changes the following:
- bring the Nix setup more in line with our other projects. 
- remove dependency on Nix User Repository (NUR)
- update the resolver to 9.0.2.